### PR TITLE
[CXP-637] prevent gRPC ResourceExhausted by paginating List, Entitlements and Grants

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.10.1
 	go.uber.org/zap v1.28.0
 )
@@ -48,7 +49,6 @@ require (
 	github.com/richardlehane/msoleps v1.0.6 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.4 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tiendc/go-deepcopy v1.7.2 // indirect
 	github.com/xuri/efp v0.0.1 // indirect
 	github.com/xuri/nfp v0.0.2-0.20250530014748-2ddeb826f9a9 // indirect

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -316,18 +316,18 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 	for i, g := range data.DirectUserGrants {
 		res, ok := c.resources[g.ResourceID]
 		if !ok {
-			l.Debug("baton-file: skipping direct grant, resource not found",
+			l.Warn("baton-file: skipping direct grant, resource not found",
 				zap.String("resource_id", g.ResourceID), zap.Int("index", i))
 			continue
 		}
 		principalRes, ok := c.resources[g.PrincipalID]
 		if !ok {
-			l.Debug("baton-file: skipping direct grant, principal id not found",
+			l.Warn("baton-file: skipping direct grant, principal id not found",
 				zap.String("principal_id", g.PrincipalID), zap.Int("index", i))
 			continue
 		}
 		if principalRes.GetId().GetResourceType() != userResourceType.GetId() {
-			l.Debug("baton-file: skipping direct grant, principal is not a user",
+			l.Warn("baton-file: skipping direct grant, principal is not a user",
 				zap.String("principal_id", g.PrincipalID),
 				zap.String("actual_type", principalRes.GetId().GetResourceType()),
 				zap.Int("index", i))
@@ -335,7 +335,7 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 		}
 		entKey := fmt.Sprintf("%s:%s", g.ResourceID, g.EntitlementSlug)
 		if _, ok := c.entitlements[entKey]; !ok {
-			l.Debug("baton-file: skipping direct grant, entitlement not found",
+			l.Warn("baton-file: skipping direct grant, entitlement not found",
 				zap.String("entitlement_key", entKey), zap.Int("index", i))
 			continue
 		}
@@ -350,31 +350,31 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 	for i, m := range data.GrantInheritanceMappings {
 		res, ok := c.resources[m.InheritedResourceID]
 		if !ok {
-			l.Debug("baton-file: skipping inheritance mapping, resource not found",
+			l.Warn("baton-file: skipping inheritance mapping, resource not found",
 				zap.String("resource_id", m.InheritedResourceID), zap.Int("index", i))
 			continue
 		}
 		if m.InheritanceDepth != "full" && m.InheritanceDepth != "shallow" {
-			l.Debug("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
+			l.Warn("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
 				zap.String("value", m.InheritanceDepth), zap.Int("index", i))
 			continue
 		}
 		principalResource, ok := c.resources[m.PrincipalResourceID]
 		if !ok {
-			l.Debug("baton-file: skipping inheritance mapping, principal resource not found",
+			l.Warn("baton-file: skipping inheritance mapping, principal resource not found",
 				zap.String("principal_resource_id", m.PrincipalResourceID), zap.Int("index", i))
 			continue
 		}
 		membershipKey := fmt.Sprintf("%s:%s", m.PrincipalResourceID, m.PrincipalEntitlementSlug)
 		membershipEntitlement, ok := c.entitlements[membershipKey]
 		if !ok {
-			l.Debug("baton-file: skipping inheritance mapping, membership entitlement not found",
+			l.Warn("baton-file: skipping inheritance mapping, membership entitlement not found",
 				zap.String("membership_key", membershipKey), zap.Int("index", i))
 			continue
 		}
 		inheritedEntKey := fmt.Sprintf("%s:%s", m.InheritedResourceID, m.InheritedEntitlementSlug)
 		if _, ok := c.entitlements[inheritedEntKey]; !ok {
-			l.Debug("baton-file: skipping inheritance mapping, inherited entitlement not found",
+			l.Warn("baton-file: skipping inheritance mapping, inherited entitlement not found",
 				zap.String("inherited_entitlement_key", inheritedEntKey), zap.Int("index", i))
 			continue
 		}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,32 +4,49 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
+	"github.com/conductorone/baton-file/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	sdkGrant "github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/conductorone/baton-file/pkg/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
 type FileConnector struct {
-	inputFilePath  string
-	validatedData  *client.LoadedData
+	inputFilePath string
+	validatedData *client.LoadedData
 }
 
 func (fc *FileConnector) Close() error { return nil }
 
 type syncCache struct {
-	loadedData    *client.LoadedData
 	resourceTypes map[string]*v2.ResourceType
 	resources     map[string]*v2.Resource
 	entitlements  map[string]*v2.Entitlement
+
+	// Pre-built indexes: constructed once in newSyncCache(), sorted, and reused
+	// on every SDK call. Values are pointers into resources/entitlements — no
+	// extra memory beyond the slice headers themselves.
+	listIndex   map[string][]*v2.Resource    // key: listKey(typeID, parent)
+	entIndex    map[string][]*v2.Entitlement // key: resourceID
+	grantsIndex map[string][]*v2.Grant       // key: resourceID
+}
+
+// listKey returns the lookup key for the listIndex.
+// top-level resources (no parent) use just the typeID.
+func listKey(typeID string, parent *v2.ResourceId) string {
+	if parent == nil {
+		return typeID
+	}
+	return typeID + "/" + parent.GetResourceType() + "/" + parent.GetResource()
 }
 
 func New(ctx context.Context, v *viper.Viper, opts *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
@@ -141,7 +158,7 @@ func (fc *FileConnector) ResourceSyncers(ctx context.Context) []connectorbuilder
 
 func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, error) {
 	l := ctxzap.Extract(ctx)
-	c := &syncCache{loadedData: data}
+	c := &syncCache{}
 
 	// 1. Discover resource types
 	c.resourceTypes = make(map[string]*v2.ResourceType)
@@ -289,6 +306,136 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 		)
 		key := fmt.Sprintf("%s:%s", e.ResourceID, e.EntitlementSlug)
 		c.entitlements[key] = ent
+	}
+
+	// 7. Pre-build grants index.
+	// All grants are constructed and sorted once here, indexed by resource ID.
+	// Grants() becomes an O(1) lookup + slice — no per-page scan or sort.
+	c.grantsIndex = make(map[string][]*v2.Grant)
+
+	for i, g := range data.DirectUserGrants {
+		res, ok := c.resources[g.ResourceID]
+		if !ok {
+			l.Debug("baton-file: skipping direct grant, resource not found",
+				zap.String("resource_id", g.ResourceID), zap.Int("index", i))
+			continue
+		}
+		principalRes, ok := c.resources[g.PrincipalID]
+		if !ok {
+			l.Debug("baton-file: skipping direct grant, principal id not found",
+				zap.String("principal_id", g.PrincipalID), zap.Int("index", i))
+			continue
+		}
+		if principalRes.GetId().GetResourceType() != userResourceType.GetId() {
+			l.Debug("baton-file: skipping direct grant, principal is not a user",
+				zap.String("principal_id", g.PrincipalID),
+				zap.String("actual_type", principalRes.GetId().GetResourceType()),
+				zap.Int("index", i))
+			continue
+		}
+		entKey := fmt.Sprintf("%s:%s", g.ResourceID, g.EntitlementSlug)
+		if _, ok := c.entitlements[entKey]; !ok {
+			l.Debug("baton-file: skipping direct grant, entitlement not found",
+				zap.String("entitlement_key", entKey), zap.Int("index", i))
+			continue
+		}
+		principalId := v2.ResourceId_builder{
+			ResourceType: userResourceType.GetId(),
+			Resource:     g.PrincipalID,
+		}.Build()
+		c.grantsIndex[g.ResourceID] = append(c.grantsIndex[g.ResourceID],
+			sdkGrant.NewGrant(res, g.EntitlementSlug, principalId))
+	}
+
+	for i, m := range data.GrantInheritanceMappings {
+		res, ok := c.resources[m.InheritedResourceID]
+		if !ok {
+			l.Debug("baton-file: skipping inheritance mapping, resource not found",
+				zap.String("resource_id", m.InheritedResourceID), zap.Int("index", i))
+			continue
+		}
+		if m.InheritanceDepth != "full" && m.InheritanceDepth != "shallow" {
+			l.Debug("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
+				zap.String("value", m.InheritanceDepth), zap.Int("index", i))
+			continue
+		}
+		principalResource, ok := c.resources[m.PrincipalResourceID]
+		if !ok {
+			l.Debug("baton-file: skipping inheritance mapping, principal resource not found",
+				zap.String("principal_resource_id", m.PrincipalResourceID), zap.Int("index", i))
+			continue
+		}
+		membershipKey := fmt.Sprintf("%s:%s", m.PrincipalResourceID, m.PrincipalEntitlementSlug)
+		membershipEntitlement, ok := c.entitlements[membershipKey]
+		if !ok {
+			l.Debug("baton-file: skipping inheritance mapping, membership entitlement not found",
+				zap.String("membership_key", membershipKey), zap.Int("index", i))
+			continue
+		}
+		inheritedEntKey := fmt.Sprintf("%s:%s", m.InheritedResourceID, m.InheritedEntitlementSlug)
+		if _, ok := c.entitlements[inheritedEntKey]; !ok {
+			l.Debug("baton-file: skipping inheritance mapping, inherited entitlement not found",
+				zap.String("inherited_entitlement_key", inheritedEntKey), zap.Int("index", i))
+			continue
+		}
+		expandable := v2.GrantExpandable_builder{
+			EntitlementIds: []string{membershipEntitlement.GetId()},
+			Shallow:        m.InheritanceDepth == "shallow",
+		}.Build()
+		c.grantsIndex[m.InheritedResourceID] = append(c.grantsIndex[m.InheritedResourceID],
+			sdkGrant.NewGrant(res, m.InheritedEntitlementSlug, principalResource.GetId(),
+				sdkGrant.WithAnnotation(expandable)))
+	}
+
+	// Sort grants once for stable pagination.
+	// Primary key: principal type + ID ("user/alice" < "user/bob").
+	// Tiebreaker: entitlement ID, so two grants to the same principal always
+	// appear in the same order across pages.
+	for resourceID := range c.grantsIndex {
+		grants := c.grantsIndex[resourceID]
+		sort.SliceStable(grants, func(left, right int) bool {
+			leftPrincipal := grants[left].GetPrincipal().GetId()
+			rightPrincipal := grants[right].GetPrincipal().GetId()
+			if leftPrincipal.GetResourceType() != rightPrincipal.GetResourceType() {
+				return leftPrincipal.GetResourceType() < rightPrincipal.GetResourceType()
+			}
+			if leftPrincipal.GetResource() != rightPrincipal.GetResource() {
+				return leftPrincipal.GetResource() < rightPrincipal.GetResource()
+			}
+			return grants[left].GetEntitlement().GetId() < grants[right].GetEntitlement().GetId()
+		})
+	}
+
+	// 8. Pre-build list index so List() is an O(1) lookup instead of a full map scan.
+	// Key is typeID for top-level resources (e.g. "group"), or
+	// typeID+"/"+parentType+"/"+parentID for children (e.g. "team/org/org1").
+	// Sorted by resource ID for stable pagination across pages.
+	c.listIndex = make(map[string][]*v2.Resource)
+	for _, res := range c.resources {
+		key := listKey(res.GetId().GetResourceType(), res.GetParentResourceId())
+		c.listIndex[key] = append(c.listIndex[key], res)
+	}
+	for key := range c.listIndex {
+		slice := c.listIndex[key]
+		sort.SliceStable(slice, func(i, j int) bool {
+			return slice[i].GetId().GetResource() < slice[j].GetId().GetResource()
+		})
+	}
+
+	// 9. Pre-build entitlements index keyed by resource ID. Entitlements() becomes
+	// an O(1) lookup instead of a full map scan per page.
+	// All entitlements for the same resource are grouped together (e.g. "eng:admin"
+	// and "eng:member" both land under entIndex["eng"]), sorted by slug for stable pagination.
+	c.entIndex = make(map[string][]*v2.Entitlement)
+	for _, ent := range c.entitlements {
+		resID := ent.GetResource().GetId().GetResource()
+		c.entIndex[resID] = append(c.entIndex[resID], ent)
+	}
+	for resID := range c.entIndex {
+		slice := c.entIndex[resID]
+		sort.SliceStable(slice, func(i, j int) bool {
+			return slice[i].GetSlug() < slice[j].GetSlug()
+		})
 	}
 
 	return c, nil

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -316,18 +316,18 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 	for i, g := range data.DirectUserGrants {
 		res, ok := c.resources[g.ResourceID]
 		if !ok {
-			l.Warn("baton-file: skipping direct grant, resource not found",
+			l.Debug("baton-file: skipping direct grant, resource not found",
 				zap.String("resource_id", g.ResourceID), zap.Int("index", i))
 			continue
 		}
 		principalRes, ok := c.resources[g.PrincipalID]
 		if !ok {
-			l.Warn("baton-file: skipping direct grant, principal id not found",
+			l.Debug("baton-file: skipping direct grant, principal id not found",
 				zap.String("principal_id", g.PrincipalID), zap.Int("index", i))
 			continue
 		}
 		if principalRes.GetId().GetResourceType() != userResourceType.GetId() {
-			l.Warn("baton-file: skipping direct grant, principal is not a user",
+			l.Debug("baton-file: skipping direct grant, principal is not a user",
 				zap.String("principal_id", g.PrincipalID),
 				zap.String("actual_type", principalRes.GetId().GetResourceType()),
 				zap.Int("index", i))
@@ -335,7 +335,7 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 		}
 		entKey := fmt.Sprintf("%s:%s", g.ResourceID, g.EntitlementSlug)
 		if _, ok := c.entitlements[entKey]; !ok {
-			l.Warn("baton-file: skipping direct grant, entitlement not found",
+			l.Debug("baton-file: skipping direct grant, entitlement not found",
 				zap.String("entitlement_key", entKey), zap.Int("index", i))
 			continue
 		}
@@ -350,31 +350,31 @@ func newSyncCache(ctx context.Context, data *client.LoadedData) (*syncCache, err
 	for i, m := range data.GrantInheritanceMappings {
 		res, ok := c.resources[m.InheritedResourceID]
 		if !ok {
-			l.Warn("baton-file: skipping inheritance mapping, resource not found",
+			l.Debug("baton-file: skipping inheritance mapping, resource not found",
 				zap.String("resource_id", m.InheritedResourceID), zap.Int("index", i))
 			continue
 		}
 		if m.InheritanceDepth != "full" && m.InheritanceDepth != "shallow" {
-			l.Warn("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
+			l.Debug("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
 				zap.String("value", m.InheritanceDepth), zap.Int("index", i))
 			continue
 		}
 		principalResource, ok := c.resources[m.PrincipalResourceID]
 		if !ok {
-			l.Warn("baton-file: skipping inheritance mapping, principal resource not found",
+			l.Debug("baton-file: skipping inheritance mapping, principal resource not found",
 				zap.String("principal_resource_id", m.PrincipalResourceID), zap.Int("index", i))
 			continue
 		}
 		membershipKey := fmt.Sprintf("%s:%s", m.PrincipalResourceID, m.PrincipalEntitlementSlug)
 		membershipEntitlement, ok := c.entitlements[membershipKey]
 		if !ok {
-			l.Warn("baton-file: skipping inheritance mapping, membership entitlement not found",
+			l.Debug("baton-file: skipping inheritance mapping, membership entitlement not found",
 				zap.String("membership_key", membershipKey), zap.Int("index", i))
 			continue
 		}
 		inheritedEntKey := fmt.Sprintf("%s:%s", m.InheritedResourceID, m.InheritedEntitlementSlug)
 		if _, ok := c.entitlements[inheritedEntKey]; !ok {
-			l.Warn("baton-file: skipping inheritance mapping, inherited entitlement not found",
+			l.Debug("baton-file: skipping inheritance mapping, inherited entitlement not found",
 				zap.String("inherited_entitlement_key", inheritedEntKey), zap.Int("index", i))
 			continue
 		}

--- a/pkg/connector/resources.go
+++ b/pkg/connector/resources.go
@@ -3,16 +3,64 @@ package connector
 import (
 	"context"
 	"fmt"
-	"sort"
+	"strconv"
 	"strings"
 
-	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/types/grant"
-	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-file/pkg/client"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
 )
+
+const pageSize = 1000
+
+// clampPageSize returns requested if it is within (0, pageSize], otherwise
+// returns pageSize. Guards against zero (SDK default) and oversized requests.
+func clampPageSize(requested int) int {
+	if requested <= 0 || requested > pageSize {
+		return pageSize
+	}
+	return requested
+}
+
+func paginate[T any](items []T, tokenStr string, tokenSize int) ([]T, string, error) {
+	// SDK sends Size=0 during sync_full; clamp converts it to pageSize so we never return an empty page.
+	size := clampPageSize(tokenSize)
+
+	// Empty token means first page; non-empty token is the numeric offset where this page starts.
+	offset := 0
+	if tokenStr != "" {
+		parsed, err := strconv.Atoi(tokenStr)
+		if err != nil {
+			return nil, "", fmt.Errorf("baton-file: invalid page token %q: %w", tokenStr, err)
+		}
+		if parsed < 0 {
+			return nil, "", fmt.Errorf("baton-file: negative page token %q", tokenStr)
+		}
+		offset = parsed
+	}
+
+	// Guard against a stale checkpoint: if the file was replaced with fewer
+	// items after an interrupted sync, offset may exceed the new slice length.
+	// Clamping here prevents items[offset:end] from panicking.
+	if offset > len(items) {
+		offset = len(items)
+	}
+
+	// Clamp end to the slice length so the last page returns only what's left.
+	end := offset + size
+	if end > len(items) {
+		end = len(items)
+	}
+
+	// Empty next token signals the SDK that there are no more pages.
+	var next string
+	if end < len(items) {
+		next = strconv.Itoa(end)
+	}
+	return items[offset:end], next, nil
+}
 
 type resourceBuilder struct {
 	cache        *syncCache
@@ -23,140 +71,34 @@ func (b *resourceBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 	return b.resourceType
 }
 
-func (b *resourceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
+func (b *resourceBuilder) List(_ context.Context, parentResourceID *v2.ResourceId,
 	opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	// Full scan is fine — resource types are single-digit and total resources
-	// are at most low thousands for a file-based connector.
-	//
-	// When parentResourceID is nil the SDK is requesting top-level resources,
-	// so we exclude any resource that has a parent. The SDK calls List() again
-	// with the parent's ID to fetch nested children.
-	var rv []*v2.Resource
-	for _, res := range b.cache.resources {
-		if res.GetId().GetResourceType() != b.resourceType.GetId() {
-			continue
-		}
-		if parentResourceID != nil {
-			if res.GetParentResourceId() == nil ||
-				res.GetParentResourceId().GetResourceType() != parentResourceID.GetResourceType() ||
-				res.GetParentResourceId().GetResource() != parentResourceID.GetResource() {
-				continue
-			}
-		} else if res.GetParentResourceId() != nil {
-			continue
-		}
-		rv = append(rv, res)
+	resources := b.cache.listIndex[listKey(b.resourceType.GetId(), parentResourceID)]
+	page, next, err := paginate(resources, opts.PageToken.Token, opts.PageToken.Size)
+	if err != nil {
+		return nil, nil, err
 	}
-	sort.SliceStable(rv, func(i, j int) bool {
-		return rv[i].GetId().GetResource() < rv[j].GetId().GetResource()
-	})
-	return rv, &rs.SyncOpResults{}, nil
+	return page, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
-// Same full-scan rationale as List() — see comment above.
-func (b *resourceBuilder) Entitlements(ctx context.Context, resource *v2.Resource,
+func (b *resourceBuilder) Entitlements(_ context.Context, resource *v2.Resource,
 	opts rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
-	var rv []*v2.Entitlement
-	for _, ent := range b.cache.entitlements {
-		if ent.GetResource().GetId().GetResourceType() == resource.GetId().GetResourceType() &&
-			ent.GetResource().GetId().GetResource() == resource.GetId().GetResource() {
-			rv = append(rv, ent)
-		}
+	ents := b.cache.entIndex[resource.GetId().GetResource()]
+	page, next, err := paginate(ents, opts.PageToken.Token, opts.PageToken.Size)
+	if err != nil {
+		return nil, nil, err
 	}
-	sort.SliceStable(rv, func(i, j int) bool {
-		return rv[i].GetSlug() < rv[j].GetSlug()
-	})
-	return rv, &rs.SyncOpResults{}, nil
+	return page, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
-// Same full-scan rationale as List() — see comment above.
-func (b *resourceBuilder) Grants(ctx context.Context, resource *v2.Resource,
+func (b *resourceBuilder) Grants(_ context.Context, resource *v2.Resource,
 	opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	l := ctxzap.Extract(ctx)
-	var allGrants []*v2.Grant
-
-	for i, g := range b.cache.loadedData.DirectUserGrants {
-		if g.ResourceID != resource.GetId().GetResource() {
-			continue
-		}
-
-		principalRes, ok := b.cache.resources[g.PrincipalID]
-		if !ok || principalRes.GetId().GetResourceType() != userResourceType.GetId() {
-			l.Warn("baton-file: skipping direct grant, principal not found in users",
-				zap.String("principal_id", g.PrincipalID), zap.Int("index", i))
-			continue
-		}
-
-		entKey := fmt.Sprintf("%s:%s", g.ResourceID, g.EntitlementSlug)
-		if _, ok := b.cache.entitlements[entKey]; !ok {
-			l.Warn("baton-file: skipping direct grant, entitlement not found",
-				zap.String("entitlement_key", entKey), zap.Int("index", i))
-			continue
-		}
-
-		principalId := v2.ResourceId_builder{
-			ResourceType: userResourceType.GetId(),
-			Resource:     g.PrincipalID,
-		}.Build()
-
-		newGrant := grant.NewGrant(resource, g.EntitlementSlug, principalId)
-		allGrants = append(allGrants, newGrant)
+	grants := b.cache.grantsIndex[resource.GetId().GetResource()]
+	page, next, err := paginate(grants, opts.PageToken.Token, opts.PageToken.Size)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	for i, m := range b.cache.loadedData.GrantInheritanceMappings {
-		if m.InheritedResourceID != resource.GetId().GetResource() {
-			continue
-		}
-
-		if m.InheritanceDepth != "full" && m.InheritanceDepth != "shallow" {
-			l.Warn("baton-file: invalid inheritance_depth, must be \"full\" or \"shallow\"",
-				zap.String("value", m.InheritanceDepth), zap.Int("index", i))
-			continue
-		}
-
-		principalResource, ok := b.cache.resources[m.PrincipalResourceID]
-		if !ok {
-			l.Warn("baton-file: skipping inheritance mapping, principal resource not found",
-				zap.String("principal_resource_id", m.PrincipalResourceID), zap.Int("index", i))
-			continue
-		}
-
-		membershipKey := fmt.Sprintf("%s:%s", m.PrincipalResourceID, m.PrincipalEntitlementSlug)
-		membershipEntitlement, ok := b.cache.entitlements[membershipKey]
-		if !ok {
-			l.Warn("baton-file: skipping inheritance mapping, membership entitlement not found",
-				zap.String("membership_key", membershipKey), zap.Int("index", i))
-			continue
-		}
-
-		expandable := v2.GrantExpandable_builder{
-			EntitlementIds: []string{membershipEntitlement.GetId()},
-			Shallow:        m.InheritanceDepth == "shallow",
-		}.Build()
-
-		newGrant := grant.NewGrant(
-			resource,
-			m.InheritedEntitlementSlug,
-			principalResource.GetId(),
-			grant.WithAnnotation(expandable),
-		)
-		allGrants = append(allGrants, newGrant)
-	}
-
-	// Sort by concatenated resource type/id rather than proto String() to
-	// ensure deterministic output across protobuf library versions.
-	sort.SliceStable(allGrants, func(i, j int) bool {
-		pi := allGrants[i].GetPrincipal().GetId()
-		pj := allGrants[j].GetPrincipal().GetId()
-		ki := pi.GetResourceType() + "/" + pi.GetResource()
-		kj := pj.GetResourceType() + "/" + pj.GetResource()
-		if ki != kj {
-			return ki < kj
-		}
-		return allGrants[i].GetEntitlement().GetId() < allGrants[j].GetEntitlement().GetId()
-	})
-
-	return allGrants, &rs.SyncOpResults{}, nil
+	return page, &rs.SyncOpResults{NextPageToken: next}, nil
 }
 
 func buildUserResource(ctx context.Context, userData client.UserData,
@@ -173,14 +115,12 @@ func buildUserResource(ctx context.Context, userData client.UserData,
 
 	userStatus := v2.UserTrait_Status_STATUS_ENABLED
 	switch strings.ToLower(userData.Status) {
-	case "enabled", "active":
-		userStatus = v2.UserTrait_Status_STATUS_ENABLED
+	case "enabled", "active", "":
+		// keep default (STATUS_ENABLED)
 	case "disabled", "inactive", "suspended":
 		userStatus = v2.UserTrait_Status_STATUS_DISABLED
 	case "deleted":
 		userStatus = v2.UserTrait_Status_STATUS_DELETED
-	case "":
-		// keep default
 	default:
 		l.Warn("baton-file: unknown user status, defaulting to enabled",
 			zap.String("user_id", userData.ID), zap.String("status", userData.Status))
@@ -189,7 +129,7 @@ func buildUserResource(ctx context.Context, userData client.UserData,
 	userAccountType := v2.UserTrait_ACCOUNT_TYPE_HUMAN
 	switch strings.ToLower(userData.Type) {
 	case "human", "":
-		userAccountType = v2.UserTrait_ACCOUNT_TYPE_HUMAN
+		// keep default (ACCOUNT_TYPE_HUMAN)
 	case "service", "system", "bot", "machine":
 		userAccountType = v2.UserTrait_ACCOUNT_TYPE_SERVICE
 	default:

--- a/pkg/connector/resources.go
+++ b/pkg/connector/resources.go
@@ -35,8 +35,8 @@ func paginate[T any](items []T, tokenStr string, tokenSize int) ([]T, string, er
 		if err != nil {
 			return nil, "", fmt.Errorf("baton-file: invalid page token %q: %w", tokenStr, err)
 		}
-		if parsed < 0 {
-			return nil, "", fmt.Errorf("baton-file: negative page token %q", tokenStr)
+		if parsed <= 0 {
+			return nil, "", fmt.Errorf("baton-file: invalid page token %q: must be a positive integer", tokenStr)
 		}
 		offset = parsed
 	}

--- a/pkg/connector/resources_test.go
+++ b/pkg/connector/resources_test.go
@@ -131,6 +131,53 @@ func TestPaginate_InvalidToken(t *testing.T) {
 	}
 }
 
+// Grants() behavior tests.
+
+func TestGrants_InheritanceMapping_ExpandableAnnotation(t *testing.T) {
+	ctx := context.Background()
+	data := &client.LoadedData{
+		Resources: []client.ResourceData{
+			{ID: "team-a", ResourceType: "group", Trait: "group", DisplayName: "Team A"},
+			{ID: "role-x", ResourceType: "role", Trait: "role", DisplayName: "Role X"},
+		},
+		Entitlements: []client.EntitlementData{
+			{ResourceID: "team-a", EntitlementSlug: "member", DisplayName: "Member"},
+			{ResourceID: "role-x", EntitlementSlug: "assigned", DisplayName: "Assigned"},
+		},
+		GrantInheritanceMappings: []client.GrantInheritanceMapping{
+			{
+				PrincipalResourceID:      "team-a",
+				PrincipalEntitlementSlug: "member",
+				InheritedResourceID:      "role-x",
+				InheritedEntitlementSlug: "assigned",
+				InheritanceDepth:         "shallow",
+			},
+		},
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["role"]}
+	grants := allGrants(t, b, cache.resources["role-x"])
+
+	require.Len(t, grants, 1)
+	require.Equal(t, "team-a", grants[0].GetPrincipal().GetId().GetResource())
+
+	// Verify GrantExpandable annotation is present with Shallow=true.
+	var expandable *v2.GrantExpandable
+	for _, ann := range grants[0].GetAnnotations() {
+		var ge v2.GrantExpandable
+		if ann.MessageIs(&ge) {
+			if err := ann.UnmarshalTo(&ge); err == nil {
+				expandable = &ge
+				break
+			}
+		}
+	}
+	require.NotNil(t, expandable, "inheritance mapping grant must have GrantExpandable annotation")
+	require.True(t, expandable.GetShallow(), "InheritanceDepth=shallow must set Shallow=true on the annotation")
+}
+
 // Grants() pagination tests.
 
 func TestGrants_PaginatesCorrectly(t *testing.T) {

--- a/pkg/connector/resources_test.go
+++ b/pkg/connector/resources_test.go
@@ -1,0 +1,315 @@
+package connector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/conductorone/baton-file/pkg/client"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/pagination"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// allGrants pages through Grants() until exhausted and returns every grant.
+func allGrants(t *testing.T, b *resourceBuilder, res *v2.Resource) []*v2.Grant {
+	t.Helper()
+	ctx := context.Background()
+	var out []*v2.Grant
+	token := ""
+	for {
+		opts := rs.SyncOpAttrs{PageToken: pagination.Token{Token: token}}
+		page, results, err := b.Grants(ctx, res, opts)
+		require.NoError(t, err)
+		out = append(out, page...)
+		if token = results.NextPageToken; token == "" {
+			break
+		}
+	}
+	return out
+}
+
+// allEntitlements pages through Entitlements() until exhausted.
+func allEntitlements(t *testing.T, b *resourceBuilder, res *v2.Resource) []*v2.Entitlement {
+	t.Helper()
+	ctx := context.Background()
+	var out []*v2.Entitlement
+	token := ""
+	for {
+		opts := rs.SyncOpAttrs{PageToken: pagination.Token{Token: token}}
+		page, results, err := b.Entitlements(ctx, res, opts)
+		require.NoError(t, err)
+		out = append(out, page...)
+		if token = results.NextPageToken; token == "" {
+			break
+		}
+	}
+	return out
+}
+
+// allResources pages through List() until exhausted.
+func allResources(t *testing.T, b *resourceBuilder, parent *v2.ResourceId) []*v2.Resource {
+	t.Helper()
+	ctx := context.Background()
+	var out []*v2.Resource
+	token := ""
+	for {
+		opts := rs.SyncOpAttrs{PageToken: pagination.Token{Token: token}}
+		page, results, err := b.List(ctx, parent, opts)
+		require.NoError(t, err)
+		out = append(out, page...)
+		if token = results.NextPageToken; token == "" {
+			break
+		}
+	}
+	return out
+}
+
+// paginate() unit tests — clampPageSize and paginate are new functions written for this fix.
+
+func TestClampPageSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		{"zero uses default", 0, pageSize},
+		{"negative uses default", -5, pageSize},
+		{"within range unchanged", 250, 250},
+		{"at max unchanged", pageSize, pageSize},
+		{"above max clamped", pageSize + 500, pageSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, clampPageSize(tt.requested))
+		})
+	}
+}
+
+func TestPaginate_Exhaustion(t *testing.T) {
+	const total = 2500
+	items := make([]int, total)
+	for i := range items {
+		items[i] = i
+	}
+	seen := make(map[int]struct{}, total)
+	token := ""
+	pages := 0
+	for {
+		page, next, err := paginate(items, token, 0)
+		require.NoError(t, err)
+		require.LessOrEqual(t, len(page), pageSize)
+		pages++
+		for _, v := range page {
+			_, dup := seen[v]
+			require.False(t, dup, "item %d returned on more than one page", v)
+			seen[v] = struct{}{}
+		}
+		if token = next; token == "" {
+			break
+		}
+		require.Less(t, pages, total, "pagination did not terminate")
+	}
+	require.Equal(t, total, len(seen))
+	require.Equal(t, (total+pageSize-1)/pageSize, pages)
+}
+
+func TestPaginate_StaleOffset(t *testing.T) {
+	items := make([]int, 50)
+	page, next, err := paginate(items, "200", 0)
+	require.NoError(t, err)
+	require.Empty(t, page)
+	require.Empty(t, next)
+}
+
+func TestPaginate_InvalidToken(t *testing.T) {
+	items := []int{1, 2, 3}
+	for _, tok := range []string{"not-a-number", "abc", "-1"} {
+		_, _, err := paginate(items, tok, 0)
+		require.Error(t, err, "token %q should return error", tok)
+	}
+}
+
+// Grants() pagination tests.
+
+func TestGrants_PaginatesCorrectly(t *testing.T) {
+	ctx := context.Background()
+	const total = 2500
+	data := &client.LoadedData{
+		Users:            make([]client.UserData, total),
+		Resources:        []client.ResourceData{{ID: "res1", ResourceType: "group", Trait: "group", DisplayName: "Big Group"}},
+		Entitlements:     []client.EntitlementData{{ResourceID: "res1", EntitlementSlug: "member", DisplayName: "Member"}},
+		DirectUserGrants: make([]client.DirectUserGrant, total),
+	}
+	for i := range total {
+		uid := fmt.Sprintf("u%05d", i)
+		data.Users[i] = client.UserData{ID: uid, DisplayName: uid}
+		data.DirectUserGrants[i] = client.DirectUserGrant{PrincipalID: uid, ResourceID: "res1", EntitlementSlug: "member"}
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
+	grants := allGrants(t, b, cache.resources["res1"])
+
+	require.Len(t, grants, total)
+	seen := make(map[string]struct{}, total)
+	for _, g := range grants {
+		key := g.GetPrincipal().GetId().GetResource()
+		_, dup := seen[key]
+		require.False(t, dup, "duplicate grant for principal %s", key)
+		seen[key] = struct{}{}
+	}
+}
+
+func TestGrants_InvalidPageToken(t *testing.T) {
+	ctx := context.Background()
+	data := &client.LoadedData{
+		Users:            []client.UserData{{ID: "u1", DisplayName: "U1"}},
+		Resources:        []client.ResourceData{{ID: "res1", ResourceType: "group", Trait: "group", DisplayName: "G"}},
+		Entitlements:     []client.EntitlementData{{ResourceID: "res1", EntitlementSlug: "member", DisplayName: "M"}},
+		DirectUserGrants: []client.DirectUserGrant{{PrincipalID: "u1", ResourceID: "res1", EntitlementSlug: "member"}},
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
+	res := cache.resources["res1"]
+
+	for _, tok := range []string{"not-a-number", "-1"} {
+		opts := rs.SyncOpAttrs{PageToken: pagination.Token{Token: tok}}
+		_, _, err := b.Grants(ctx, res, opts)
+		require.Error(t, err, "token %q should return error", tok)
+	}
+}
+
+// Entitlements() pagination tests.
+
+func TestEntitlements_PaginatesCorrectly(t *testing.T) {
+	ctx := context.Background()
+	const total = 1500
+	entsData := make([]client.EntitlementData, total)
+	for i := range total {
+		entsData[i] = client.EntitlementData{
+			ResourceID:      "res1",
+			EntitlementSlug: fmt.Sprintf("perm-%04d", i),
+			DisplayName:     fmt.Sprintf("Permission %04d", i),
+		}
+	}
+	data := &client.LoadedData{
+		Resources:    []client.ResourceData{{ID: "res1", ResourceType: "role", Trait: "role", DisplayName: "Big Role"}},
+		Entitlements: entsData,
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["role"]}
+	ents := allEntitlements(t, b, cache.resources["res1"])
+
+	require.Len(t, ents, total)
+	seen := make(map[string]struct{}, total)
+	for _, e := range ents {
+		_, dup := seen[e.GetSlug()]
+		require.False(t, dup, "duplicate entitlement slug %s", e.GetSlug())
+		seen[e.GetSlug()] = struct{}{}
+	}
+}
+
+func TestEntitlements_OnlyForRequestedResource(t *testing.T) {
+	ctx := context.Background()
+	data := &client.LoadedData{
+		Resources: []client.ResourceData{
+			{ID: "eng", ResourceType: "group", Trait: "group", DisplayName: "Engineering"},
+			{ID: "mkt", ResourceType: "group", Trait: "group", DisplayName: "Marketing"},
+		},
+		Entitlements: []client.EntitlementData{
+			{ResourceID: "eng", EntitlementSlug: "member", DisplayName: "Member"},
+			{ResourceID: "mkt", EntitlementSlug: "member", DisplayName: "Member"},
+		},
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
+	ents := allEntitlements(t, b, cache.resources["eng"])
+
+	require.Len(t, ents, 1, "must only return entitlements for the requested resource")
+	require.Equal(t, "eng", ents[0].GetResource().GetId().GetResource())
+}
+
+// List() pagination tests.
+
+func TestList_PaginatesCorrectly(t *testing.T) {
+	ctx := context.Background()
+	const total = 1500
+	resources := make([]client.ResourceData, total)
+	for i := range total {
+		resources[i] = client.ResourceData{
+			ID:           fmt.Sprintf("g%05d", i),
+			ResourceType: "group",
+			Trait:        "group",
+			DisplayName:  fmt.Sprintf("Group %05d", i),
+		}
+	}
+	data := &client.LoadedData{Resources: resources}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
+	got := allResources(t, b, nil)
+
+	require.Len(t, got, total)
+	seen := make(map[string]struct{}, total)
+	for _, r := range got {
+		_, dup := seen[r.GetId().GetResource()]
+		require.False(t, dup, "duplicate resource %s", r.GetId().GetResource())
+		seen[r.GetId().GetResource()] = struct{}{}
+	}
+}
+
+func TestList_ReturnsCorrectResourceType(t *testing.T) {
+	ctx := context.Background()
+	data := &client.LoadedData{
+		Users: []client.UserData{{ID: "alice", DisplayName: "Alice"}},
+		Resources: []client.ResourceData{
+			{ID: "eng", ResourceType: "group", Trait: "group", DisplayName: "Engineering"},
+			{ID: "viewer", ResourceType: "role", Trait: "role", DisplayName: "Viewer"},
+		},
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
+	resources := allResources(t, b, nil)
+
+	require.Len(t, resources, 1)
+	require.Equal(t, "eng", resources[0].GetId().GetResource())
+	require.Equal(t, "group", resources[0].GetId().GetResourceType())
+}
+
+func TestList_FiltersByParent(t *testing.T) {
+	ctx := context.Background()
+	data := &client.LoadedData{
+		Resources: []client.ResourceData{
+			{ID: "org1", ResourceType: "org", Trait: "group", DisplayName: "Org 1"},
+			{ID: "team-a", ResourceType: "team", Trait: "group", DisplayName: "Team A", ParentResource: "org1"},
+			{ID: "team-b", ResourceType: "team", Trait: "group", DisplayName: "Team B", ParentResource: "org1"},
+			{ID: "team-c", ResourceType: "team", Trait: "group", DisplayName: "Team C"},
+		},
+	}
+	cache, err := newSyncCache(ctx, data)
+	require.NoError(t, err)
+
+	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["team"]}
+
+	topLevel := allResources(t, b, nil)
+	require.Len(t, topLevel, 1)
+	require.Equal(t, "team-c", topLevel[0].GetId().GetResource())
+
+	children := allResources(t, b, &v2.ResourceId{ResourceType: "org", Resource: "org1"})
+	require.Len(t, children, 2)
+	ids := map[string]bool{children[0].GetId().GetResource(): true, children[1].GetId().GetResource(): true}
+	require.True(t, ids["team-a"])
+	require.True(t, ids["team-b"])
+}

--- a/pkg/connector/resources_test.go
+++ b/pkg/connector/resources_test.go
@@ -125,7 +125,7 @@ func TestPaginate_StaleOffset(t *testing.T) {
 
 func TestPaginate_InvalidToken(t *testing.T) {
 	items := []int{1, 2, 3}
-	for _, tok := range []string{"not-a-number", "abc", "-1"} {
+	for _, tok := range []string{"not-a-number", "abc", "-1", "0"} {
 		_, _, err := paginate(items, tok, 0)
 		require.Error(t, err, "token %q should return error", tok)
 	}
@@ -224,7 +224,7 @@ func TestGrants_InvalidPageToken(t *testing.T) {
 	b := &resourceBuilder{cache: cache, resourceType: cache.resourceTypes["group"]}
 	res := cache.resources["res1"]
 
-	for _, tok := range []string{"not-a-number", "-1"} {
+	for _, tok := range []string{"not-a-number", "-1", "0"} {
 		opts := rs.SyncOpAttrs{PageToken: pagination.Token{Token: tok}}
 		_, _, err := b.Grants(ctx, res, opts)
 		require.Error(t, err, "token %q should return error", tok)


### PR DESCRIPTION
paginate List, Entitlements and Grants to prevent gRPC ResourceExhausted on large datasets; pre-build sorted indexes in syncCache for O(1) lookups

#### Description

- [ ] Bug fix
- [ ] New feature




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
